### PR TITLE
TASK: Add node prop for editable component

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Editable.fusion
+++ b/Resources/Private/Fusion/Prototypes/Editable.fusion
@@ -1,13 +1,14 @@
 prototype(PackageFactory.AtomicFusion:Editable) < prototype(PackageFactory.AtomicFusion:Component) {
+	node = ${node}
 	property = null
 	block = true
 
 	renderer = Neos.Fusion:Case {
 		editable {
-			condition = ${node.context.inBackend && node.context.currentRenderingMode.edit}
+			condition = ${props.node.context.inBackend && props.node.context.currentRenderingMode.edit}
 			renderer = Neos.Fusion:Tag {
 				tagName = ${props.block ? 'div' : 'span'}
-				content = ${q(node).property(props.property)}
+				content = ${q(props.node).property(props.property)}
 				@process.contentElementEditableWrapping = Neos.Neos:ContentElementEditable {
 					property = ${props.property}
 				}
@@ -17,7 +18,7 @@ prototype(PackageFactory.AtomicFusion:Editable) < prototype(PackageFactory.Atomi
 
 		notEditable {
 			condition = true
-			renderer = ${q(node).property(props.property)}
+			renderer = ${q(props.node).property(props.property)}
 		}
 	}
 }


### PR DESCRIPTION
With this it's possible  to specify the edited node as part of the editable API, instead than over the context - while the latter is still the default behavior.