### PR TITLE
BUGFIX: use specified node as context for property editing

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Editable.fusion
+++ b/Resources/Private/Fusion/Prototypes/Editable.fusion
@@ -11,6 +11,7 @@ prototype(PackageFactory.AtomicFusion:Editable) < prototype(PackageFactory.Atomi
 				content = ${q(props.node).property(props.property)}
 				@process.contentElementEditableWrapping = Neos.Neos:ContentElementEditable {
 					property = ${props.property}
+					node = ${props.node}
 				}
 				@if.hasProperty = ${props.property ? true : false}
 			}


### PR DESCRIPTION
Wrapping the element in a Neos.Neos:ContentElementWrapping did not
suffice for the ContentElementEditable object to load the correct node's
property e.g. when the given node is rendered as collection item.