### PR TITLE
FEATURE: Expose fusion object name

### DIFF
--- a/Classes/PackageFactory/AtomicFusion/FusionObjects/ComponentImplementation.php
+++ b/Classes/PackageFactory/AtomicFusion/FusionObjects/ComponentImplementation.php
@@ -36,6 +36,16 @@ class ComponentImplementation extends ArrayImplementation
     protected $ignoreProperties = ['__meta', 'renderer'];
 
     /**
+     * Expose fusion object name for component reflection
+     *
+     * @return string
+     */
+    public function getFusionObjectName()
+    {
+        return $this->fusionObjectName;
+    }
+
+    /**
      * Get the component props as an associative array
      *
      * @return array


### PR DESCRIPTION
With this, you will have in-fusion access to the `fusionObjectName` of the current component, like this:

```
prototype(Vendor.Site:Component.MyComponent) < prototype(PackageFactory.AtomicFusion:Component) {
    componentName = ${this.fusionObjectName}
    // returns Vendor.Site:Component.MyComponent
}
```

This is very useful for reflection based Features like template discovery or CSS modules.